### PR TITLE
Add cursor for dropdowns

### DIFF
--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -233,7 +233,7 @@ main hr {
 }
 
 /* Make dropdowns have the right cursor */
-li.dropdown {
- cursor: pointer;
+li.dropdown #nav.dropdown-toggle {
+  cursor: pointer;
 }
 

--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -231,3 +231,9 @@ main hr {
     min-width: 48%;
   }
 }
+
+/* Make dropdowns have the right cursor */
+li.dropdown {
+ cursor: pointer;
+}
+


### PR DESCRIPTION
This 'fixes' the dropdowns which currently have a caret cursor, but should have a pointer, so as to feel like a real menu.